### PR TITLE
Run Composer using `hhvm` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,6 @@ You can clone it wherever you like, but for this example I'm putting it in ~/hac
     cd ~
     git clone https://github.com/hhvm/hack-example-site.git
     
-#### Install dependencies ####
-The Hack Example Site uses [Composer](https://getcomposer.org) to manage its dependencies. Composer is easy to install and easy to use. To install Composer, you just curl the installation script. To install the dependencies you just run the `install` command. For more information about this step, see the Composer [getting started guide](https://getcomposer.org/doc/00-intro.md#installation-nix).
-
-    cd hack-example-site
-    sudo apt-get install curl
-    curl -sS https://getcomposer.org/installer | php
-    php composer.phar install
-    
 #### Install Nginx
 
     sudo apt-get install nginx
@@ -59,6 +51,14 @@ The Hack Example Site uses [Composer](https://getcomposer.org) to manage its dep
     echo deb http://dl.hhvm.com/ubuntu saucy main | sudo tee /etc/apt/sources.list.d/hhvm.list 
     sudo apt-get update
     sudo apt-get install hhvm
+
+#### Install dependencies ####
+The Hack Example Site uses [Composer](https://getcomposer.org) to manage its dependencies. Composer is easy to install and easy to use. To install Composer, you just curl the installation script and pipe into `php` (the `hhvm` executable cannot read a script from `STDIN` currently). To install the dependencies you just run the `install` command; we are invoking the downloaded `composer.phar` using `hhvm` to make sure the engine dependency in `composer.json` is satisfied. For more information about this step, see the Composer [getting started guide](https://getcomposer.org/doc/00-intro.md#installation-nix).
+
+    cd hack-example-site
+    sudo apt-get install curl
+    curl -sS https://getcomposer.org/installer | php
+    hhvm composer.phar install
 
 #### Copy the HHVM config file
 There is a simple HHVM config in this repo, which you can use. I just overwrite the server.hdf file, since that's the config that init.d uses. You can always edit the service or start hhvm yourself if you'd rather not overwrite server.hdf

--- a/README.md
+++ b/README.md
@@ -94,20 +94,15 @@ Try going to `localhost` in your browser of choice
 
 If you don't already have a Heroku account, start here: https://id.heroku.com/signup
 
-#### Clone the repo and check out the `heroku` branch
+#### Create a Heroku app, push the code, and open the app in your browser
 
-    git clone https://github.com/pvh/hack-example-site.git
-    cd hack-example-site
-
-#### Add a "Procfile" which tells Heroku to start your app using HHVM
-
-    echo 'web: vendor/bin/heroku-hhvm-nginx' > Procfile
-    git add .
-    git commit -am "add a Procfile so that foreman/heroku know how to start the app"
-
-#### Create a heroku app and push the code
-
-    heroku create --buildpack https://github.com/dzuelke/heroku-buildpack-php#hhvm
+    heroku create
     git push heroku master
     heroku open
 
+#### Optionally, add a "Procfile" telling Heroku to start your app using Nginx instead of the default Apache
+
+    echo 'web: vendor/bin/heroku-hhvm-nginx' > Procfile # could also be heroku-hhvm-apache2 instead
+    git add Procfile
+    git commit -m "use Nginx on Heroku"
+    git push heroku master

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "hhvm/hack-example-site",
   "description": "An example website built with Hack",
   "require": {
-     "hhvm/xhp": "1.5.0"
+    "hhvm": ">=3.0.1",
+    "hhvm/xhp": "1.5.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "9a8f6c949e9c91c5b2e1f67d349d6ce4",
+    "hash": "b9aefbeff4c6a83128f6387a21f4aad2",
     "packages": [
         {
             "name": "hhvm/xhp",
@@ -34,9 +34,9 @@
     "stability-flags": [
 
     ],
-    "platform": [
-
-    ],
+    "platform": {
+        "hhvm": ">=3.0.1"
+    },
     "platform-dev": [
 
     ]


### PR DESCRIPTION
Adds back the `hhvm` engine dependency, too.

Easy, and teaches people the right thing :)

Also adjusted the Heroku instructions to reflect recent changes there.
