### PR TITLE
Fix #11 tuple() compatibility, fix README.md install on heroku.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ If you don't already have a Heroku account, start here: https://id.heroku.com/si
 
 #### Create a heroku app and push the code
 
-    heroku create --buildpack https://github.com/dzuelke/heroku-buildpack-php#hhvm
     git push heroku master
     heroku open
 

--- a/core/funs/funs.php
+++ b/core/funs/funs.php
@@ -30,7 +30,3 @@ function invariant_violation(string $message): void {
 function class_meth(string $class, string $method) {
   return array($class, $method);
 }
-
-function tuple(...) {
-  return func_get_args();
-}


### PR DESCRIPTION
Following the README.MD instructions:

```
> git push heroku master
The authenticity of host 'heroku.com (50.19.85.132)' can't be established.
RSA key fingerprint is 8b:48:5e:67:0e:c9:16:47:32:f2:87:0c:1f:c8:60:ad.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'heroku.com,50.19.85.132' (RSA) to the list of known hosts.
Initializing repository, done.
Counting objects: 250, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (156/156), done.
Writing objects: 100% (250/250), 107.04 KiB | 0 bytes/s, done.
Total 250 (delta 89), reused 246 (delta 87)


-----> Fetching custom git buildpack... done
-----> PHP app detected

 !     ERROR:        The 'hhvm' branch of this buildpack is no longer supported.
       Please use the release version by unsetting BUILDPACK_URL in your
       configuration using 'heroku config:unset BUILDPACK_URL'.
       See http://devcenter.heroku.com/categories/php for more information.


 !     Push rejected, failed to compile PHP app

To git@heroku.com:pure-mesa-4747.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'git@heroku.com:pure-mesa-4747.git'
```

I've tried using the default buildpack as suggested by Heroku, but I'm getting WSOD on all examples.
## The fix
- `tuple()` is part of HHVM core now.
- Readme refered to deprecated heroku buildkit + branch which is not required any more (Heroku handles that)
