### PR TITLE
Update get-and-post recipe to use new Map initialization

### DIFF
--- a/recipes/get-and-post/NonStrictFile.php
+++ b/recipes/get-and-post/NonStrictFile.php
@@ -13,12 +13,12 @@ function getGETParams(): Map<string, mixed> {
   // $_GET is not defined in code so Hack doesn't know about it and you can't
   // use it in strict mode. You can interact with it outside of strict mode,
   // though.
-  return Map::fromArray($_GET);
+  return new Map($_GET);
 }
 
 function getPOSTParams(): Map<string, mixed> {
   // Same deal with $_POST and other magically defined globals
-  return Map::fromArray($_POST);
+  return new Map($_POST);
 }
 
 // Same deal with $_SERVER


### PR DESCRIPTION
`Map::fromArray` seems to have been deprecated in favor of `new Map`. This updates this example to reflect that.